### PR TITLE
Test for localStorage

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ var onIdle = require('on-idle')
 var assert = require('assert')
 
 var hasWindow = typeof window !== 'undefined'
-var disabled = hasWindow && window.localStorage.DISABLE_NANOTIMING === 'true'
+var hasLocalStorage = hasWindow && 'localStorage' in window
+var disabled = hasLocalStorage && window.localStorage.DISABLE_NANOTIMING === 'true'
 var perf = hasWindow && window.performance
 var hasPerf = perf && perf.mark
 


### PR DESCRIPTION
When testing in node (with jsdom), `window` is present, but not `window.localStorage`, so `window.localStorage.DISABLE_NANOTIMING` attempts to set `DISABLE_NANOTIMING` on `undefined`. This resolves that (though technically [truly detecting localStorage can be more complicated](https://mathiasbynens.be/notes/localstorage-pattern)).