### PR TITLE
Tests!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ sudo: false
 language: node_js
 script: "npm run test"
 # after_success: "npm i -g codecov && npm run coverage && codecov"
+before_script:
+  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start

--- a/package.json
+++ b/package.json
@@ -7,17 +7,18 @@
   "browser": "browser.js",
   "scripts": {
     "start": "node .",
-    "test": "standard",
+    "test": "standard && (browserify test.js | tape-run)",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov"
   },
   "dependencies": {
     "nanoscheduler": "^1.0.2"
   },
   "devDependencies": {
-    "dependency-check": "^2.8.0",
+    "browserify": "^14.5.0",
     "nyc": "^10.2.0",
     "standard": "^10.0.1",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "tape-run": "^3.0.0"
   },
   "keywords": [
     "browser",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "browser": "browser.js",
   "scripts": {
     "start": "node .",
-    "test": "standard && (browserify test.js | tape-run)",
+    "test": "standard && browserify test.js | tape-run",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov"
   },
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,62 @@
+var test = require('tape')
+var nanotiming = require('./')
+
+test('nanotiming(name) returns endTiming function', function (t) {
+  var endTiming = nanotiming('foo')
+  var timings = window.performance.getEntries()
+  var timing = timings[timings.length - 1]
+  window.performance.clearMeasures(timing.name)
+  if (typeof endTiming === 'function') {
+    t.pass('is a function')
+    endTiming()
+  } else {
+    t.fail('should be a function, but is ' + typeof endTiming)
+  }
+  t.end()
+})
+
+test('endTiming.uuid is a string', function (t) {
+  var endTiming = nanotiming('foo')
+  var timings = window.performance.getEntries()
+  var timing = timings[timings.length - 1]
+  window.performance.clearMeasures(timing.name)
+  endTiming()
+  t.equal(typeof endTiming.uuid, 'string')
+  t.end()
+})
+
+test('endTiming callback receives the timing name', function (t) {
+  t.plan(1)
+  var endTiming = nanotiming('foo')
+  var timings = window.performance.getEntries()
+  var timing = timings[timings.length - 1]
+  window.performance.clearMeasures(timing.name)
+  endTiming(name => t.equal(name, 'foo', 'name: ' + name))
+})
+
+test.skip('is disabled when no window.performance.mark in environment', function (t) {
+  t.plan(1)
+
+  var mark = window.performance.mark
+  window.performance.mark = undefined
+  // TODO: need a way to run the "disabled" check again
+
+  var noop = nanotiming('foo')
+  noop(() => t.fail('called the callback, but should have been a noop'))
+  setTimeout(t.pass)
+
+  window.performance.mark = mark
+})
+
+test.skip('is disabled when window.localStorage.DISABLE_NANOTIMING === "true"', function (t) {
+  t.plan(1)
+
+  window.localStorage.DISABLE_NANOTIMING = true
+  // TODO: need a way to run the "disabled" check again
+
+  var noop = nanotiming('foo')
+  noop(() => t.fail('called the callback, but should have been a noop'))
+  setTimeout(t.pass)
+
+  window.localStorage.removeItem('DISABLE_NANOTIMING')
+})


### PR DESCRIPTION
Here's some tests! They might be awful, but it's a start. I don't think it's possible to test whether timing is disabled without wrapping everything in an extra function, then `module.exports = require('./that-function')()`. It would be good to do something so that the feature detection can be refreshed for the sake of testing. Meanwhile, the `disabled` tests are skipped.