### PR TITLE
Bugfix: don't break in sandboxed environments, simpler feature detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,19 @@
 var onIdle = require('on-idle')
 var assert = require('assert')
 
-var hasWindow = typeof window !== 'undefined'
-var hasLocalStorage = hasWindow && 'localStorage' in window
-var disabled = hasLocalStorage && window.localStorage.DISABLE_NANOTIMING === 'true'
-var perf = hasWindow && window.performance
-var hasPerf = perf && perf.mark
+var perf
+var disabled = true
+try {
+  perf = window.performance
+  disabled = window.localStorage.DISABLE_NANOTIMING === 'true' || !perf.mark
+} catch (e) { }
 
 module.exports = nanotiming
 
 function nanotiming (name) {
   assert.equal(typeof name, 'string', 'nanotiming: name should be type string')
 
-  if (!hasPerf || disabled) return noop
+  if (disabled) return noop
 
   var uuid = (perf.now() * 100).toFixed()
   var startName = 'start-' + uuid + '-' + name


### PR DESCRIPTION
Fixes https://github.com/choojs/nanotiming/issues/6 wherein accessing `window.localStorage` made the package throw in a sandbox where localStorage access is restricted. This made it and its dependents unusable in such a sandbox.

Also simplifies the feature detection logic and maybe makes it more solid.