### PR TITLE
rm uuid trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Timings inside the view are appended with a unique UUID so they can be cleared
 individually. While there's no strict format for timing formats, we recommend
 using a format along these lines:
 ```txt
-choo.render [12356778]
-choo.route('/') [13355671]
-choo.emit('log:debug') [13355675]
+choo.render
+choo.route('/')
+choo.emit('log:debug')
 ```
 
 ## Disabling timings

--- a/index.js
+++ b/index.js
@@ -25,8 +25,7 @@ function nanotiming (name) {
     perf.mark(endName)
 
     onIdle(function () {
-      var measureName = name + ' [' + uuid + ']'
-      perf.measure(measureName, startName, endName)
+      perf.measure(name, startName, endName)
       perf.clearMarks(startName)
       perf.clearMarks(endName)
       if (cb) cb(name)

--- a/index.js
+++ b/index.js
@@ -25,9 +25,11 @@ function nanotiming (name) {
     perf.mark(endName)
 
     onIdle(function () {
-      perf.measure(name, startName, endName)
-      perf.clearMarks(startName)
-      perf.clearMarks(endName)
+      try {
+        perf.measure(name, startName, endName)
+        perf.clearMarks(startName)
+        perf.clearMarks(endName)
+      } catch (e) {}
       if (cb) cb(name)
     })
   }


### PR DESCRIPTION
Remove the trailing thingies in measures, because `on-performance` makes it so we don't need them. Thanks!