### PR TITLE
more accurate timings

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function nanotiming (name) {
 
   if (disabled) return noop
 
-  var uuid = (perf.now() * 100).toFixed()
+  var uuid = (perf.now() * 10000).toFixed() % Number.MAX_SAFE_INTEGER
   var startName = 'start-' + uuid + '-' + name
   perf.mark(startName)
 


### PR DESCRIPTION
We've been seeing some conflicts in timings; this makes it hyper unlikely that any conflicts ever occur because of accidental double labeling of things.

Because the number is now larger, we're also adding a module for the largest number so the clock will keep on ticking – even in long lived applications. Thanks!