### PR TITLE
make nanotiming work in node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 node_js:
-- "4"
-- "5"
-- "6"
-- "7"
+- "8.5"
+- "9"
 sudo: false
 language: node_js
 script: "npm run test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 node_js:
-- "8.5"
+- "7"
+- "8"
 - "9"
 sudo: false
 language: node_js

--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 [![downloads][8]][9] [![js-standard-style][10]][11]
 
 Small timing library. Useful to integrate into libraries that have multiple
-methods. Only works in the browser, does nothing in Node.
+methods. Works both in the browser and Node. To use this in Node, make sure you
+are using v8.5.0 or greater.
 
 ## Usage
 ```js
 var nanotiming = require('nanotiming')
+// require 'perf_hooks' for Node environment
+// var performance = require('perf_hooks').performance
 
 var timing = nanotiming('my-loop') // Start profiling
 
@@ -15,17 +18,19 @@ var i = 1000
 while (--i) console.log(i)
 
 // Stop profiling
-timing(function (err) {
-  if (err) return
+timing()
 
-  // Inspect timings when we have spare time available
-  window.requestIdleCallback(function () {
-    var timings = window.performance.getEntries()
-    var timing = timings[timings.length - 1]
-    console.log(timing.name, timing.duration) // log the last entry
-    performance.clearMeasures(timing.name)    // be a good citizen and free after use
-  })
-})
+// in the browser
+var timings = window.performance.getEntries()
+var timing = timings[timings.length - 1]
+console.log(timing.name, timing.duration) // log the last entry
+window.performance.clearMeasures(timing.name)    // be a good citizen and free after use
+
+// in Node 
+var timings = performance.getEntries()
+var timing = timings[timings.length - 1]
+console.log(timing.name, timing.duration) // log the last entry
+performance.clearMeasures(timing.name)    // be a good citizen and free after use
 ```
 
 ## Timing names
@@ -40,10 +45,14 @@ choo.emit('log:debug') [13355675]
 
 ## Disabling timings
 Performance timers are still a somewhat experimental technology. While they're
-a great idea conceptually, there might be bugs. To disable timings complete,
-set:
+a great idea conceptually, there might be bugs. To disable timings complete, in
+the browser set:
 ```js
 window.localStorage.DISABLE_NANOTIMING = true
+```
+Alternatively, in Node set:
+```js
+process.env.DISABLE_NANOTIMING = true
 ```
 
 ## API
@@ -55,8 +64,9 @@ The unique ID created for the timing.
 
 ### `endTiming([cb(err, name)])`
 Close the timing. Measuring the timing is done inside a `requestIdleCallback()`
-tick, so it might not be available immediately. If a callback is passed it will
-be called with an error (if measuring wasn't successful) and the timing's name.
+(browser) or `setTimeout` (node) tick, so it might not be available
+immediately. If a callback is passed it will be called with an error (if
+measuring wasn't successful) and the timing's name.
 
 ## License
 [MIT](https://tldrlegal.com/license/mit-license)

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,48 @@
+var scheduler = require('nanoscheduler')()
+var assert = require('assert')
+
+var perf
+var disabled = true
+try {
+  perf = window.performance
+  disabled = window.localStorage.DISABLE_NANOTIMING === 'true' || !perf.mark
+} catch (e) { }
+
+module.exports = nanotiming
+
+function nanotiming (name) {
+  assert.equal(typeof name, 'string', 'nanotiming: name should be type string')
+
+  if (disabled) return noop
+
+  var uuid = (perf.now() * 10000).toFixed() % Number.MAX_SAFE_INTEGER
+  var startName = 'start-' + uuid + '-' + name
+  perf.mark(startName)
+
+  function end (cb) {
+    var endName = 'end-' + uuid + '-' + name
+    perf.mark(endName)
+
+    scheduler.push(function () {
+      var err = null
+      try {
+        var measureName = name + ' [' + uuid + ']'
+        perf.measure(measureName, startName, endName)
+        perf.clearMarks(startName)
+        perf.clearMarks(endName)
+      } catch (e) { err = e }
+      if (cb) cb(err, name)
+    })
+  }
+
+  end.uuid = uuid
+  return end
+}
+
+function noop (cb) {
+  if (cb) {
+    scheduler.push(function () {
+      cb(new Error('nanotiming: performance API unavailable'))
+    })
+  }
+}

--- a/example.js
+++ b/example.js
@@ -1,0 +1,15 @@
+var nanotiming = require('./')
+var performance = require('perf_hooks').performance
+
+var timing = nanotiming('my-loop') // Start profiling
+
+var i = 10
+while (--i) console.log(i)
+
+// Stop profiling
+timing()
+
+var timings = performance.getEntries()
+var timing = timings[timings.length - 1]
+console.log(timing.name, timing.duration) // log the last entry
+performance.clearMeasures(timing.name)    // be a good citizen and free after use

--- a/example.js
+++ b/example.js
@@ -1,13 +1,13 @@
 var nanotiming = require('./')
 var performance = require('perf_hooks').performance
 
-var timing = nanotiming('my-loop') // Start profiling
+var nanot = nanotiming('my-loop') // Start profiling
 
 var i = 10
 while (--i) console.log(i)
 
 // Stop profiling
-timing()
+nanot()
 
 var timings = performance.getEntries()
 var timing = timings[timings.length - 1]

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ try {
 module.exports = nanotiming
 
 function nanotiming (name) {
+  if (typeof window !== 'undefined') return require('./browser.js')(name) // electron suport
+
   assert.equal(typeof name, 'string', 'nanotiming: name should be type string')
 
   if (disabled) return noop

--- a/package.json
+++ b/package.json
@@ -3,12 +3,11 @@
   "description": "Small timing library",
   "repository": "choojs/nanotiming",
   "version": "7.1.0",
-  "browser": "browser.js",
   "main": "index.js",
+  "browser": "browser.js",
   "scripts": {
-    "deps": "dependency-check . && dependency-check . --extra --no-dev",
     "start": "node .",
-    "test": "standard && npm run deps",
+    "test": "standard",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "description": "Small timing library",
   "repository": "choojs/nanotiming",
   "version": "7.1.0",
+  "browser": "browser.js",
+  "main": "index.js",
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev",
     "start": "node .",


### PR DESCRIPTION
This PR adapts nanotiming to work with Node > 8.5.0.

There is now a separate file for the browser version -- `browser.js`. Node version lives in `index.js`. Both are reflected in `package.json`.

Thanks for your time ^____^