### PR TITLE
Allow nanotiming to be disabled after module initialization

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -2,10 +2,10 @@ var scheduler = require('nanoscheduler')()
 var assert = require('assert')
 
 var perf
-var disabled = true
+nanotiming.disabled = true
 try {
   perf = window.performance
-  disabled = window.localStorage.DISABLE_NANOTIMING === 'true' || !perf.mark
+  nanotiming.disabled = window.localStorage.DISABLE_NANOTIMING === 'true' || !perf.mark
 } catch (e) { }
 
 module.exports = nanotiming
@@ -13,7 +13,7 @@ module.exports = nanotiming
 function nanotiming (name) {
   assert.equal(typeof name, 'string', 'nanotiming: name should be type string')
 
-  if (disabled) return noop
+  if (nanotiming.disabled) return noop
 
   var uuid = (perf.now() * 10000).toFixed() % Number.MAX_SAFE_INTEGER
   var startName = 'start-' + uuid + '-' + name

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var assert = require('assert')
 
 var perf
-var disabled = true
+nanotiming.disabled = true
 try {
   perf = require('perf_hooks').performance
-  disabled = process.env.DISABLE_NANOTIMING || !perf.mark
+  nanotiming.disabled = process.env.DISABLE_NANOTIMING || !perf.mark
 } catch (e) { }
 
 module.exports = nanotiming
@@ -14,7 +14,7 @@ function nanotiming (name) {
 
   assert.equal(typeof name, 'string', 'nanotiming: name should be type string')
 
-  if (disabled) return noop
+  if (nanotiming.disabled) return noop
 
   var uuid = (perf.now() * 10000).toFixed() % Number.MAX_SAFE_INTEGER
   var startName = 'start-' + uuid + '-' + name


### PR DESCRIPTION
Hi!

I'd like to be able to disable / enable nanotiming while my app is running. I went ahead and implemented it in the simplest way I could think of. Maybe other folks will find this or something like it useful.