### PR TITLE
Fix issue with uuid being the same value in Safari

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -10,23 +10,25 @@ try {
 
 module.exports = nanotiming
 
+window._nanotiming_id = 0
+
 function nanotiming (name) {
   assert.equal(typeof name, 'string', 'nanotiming: name should be type string')
 
   if (nanotiming.disabled) return noop
 
-  var uuid = (perf.now() * 10000).toFixed() % Number.MAX_SAFE_INTEGER
-  var startName = 'start-' + uuid + '-' + name
+  var id = (++window._nanotiming_id) % Number.MAX_SAFE_INTEGER
+  var startName = 'start-' + id + '-' + name
   perf.mark(startName)
 
   function end (cb) {
-    var endName = 'end-' + uuid + '-' + name
+    var endName = 'end-' + id + '-' + name
     perf.mark(endName)
 
     scheduler.push(function () {
       var err = null
       try {
-        var measureName = name + ' [' + uuid + ']'
+        var measureName = name + ' [' + id + ']'
         perf.measure(measureName, startName, endName)
         perf.clearMarks(startName)
         perf.clearMarks(endName)
@@ -35,7 +37,7 @@ function nanotiming (name) {
     })
   }
 
-  end.uuid = uuid
+  end.id = id
   return end
 }
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ try {
 
 module.exports = nanotiming
 
+global._nanotiming_id = 0
+
 function nanotiming (name) {
   if (typeof window !== 'undefined') return require('./browser.js')(name) // electron suport
 
@@ -16,17 +18,17 @@ function nanotiming (name) {
 
   if (nanotiming.disabled) return noop
 
-  var uuid = (perf.now() * 10000).toFixed() % Number.MAX_SAFE_INTEGER
-  var startName = 'start-' + uuid + '-' + name
+  var id = (++global._nanotiming_id) % Number.MAX_SAFE_INTEGER
+  var startName = 'start-' + id + '-' + name
   perf.mark(startName)
 
   function end (cb) {
-    var endName = 'end-' + uuid + '-' + name
+    var endName = 'end-' + id + '-' + name
     perf.mark(endName)
 
     var err = null
     try {
-      var measureName = name + ' [' + uuid + ']'
+      var measureName = name + ' [' + id + ']'
       perf.measure(measureName, startName, endName)
       perf.clearMarks(startName)
       perf.clearMarks(endName)
@@ -34,7 +36,7 @@ function nanotiming (name) {
     if (cb) cb(err, name)
   }
 
-  end.uuid = uuid
+  end.id = id
   return end
 }
 


### PR DESCRIPTION
When using nanotiming from within a loop, `perf.now()` might return the
same value twice causing a `DOMException` to be thrown.

I've made the same change to `browser.js` and `index.js` because even if this rarely happens in practice, I think this library shouldn't rely on the accuracy of the hosts `performace` implementation.

Fixed #18